### PR TITLE
Renamed Referral attribute "name" -> "label"

### DIFF
--- a/src/components/dashboard/services/referral/ReferralsDataTable.tsx
+++ b/src/components/dashboard/services/referral/ReferralsDataTable.tsx
@@ -28,7 +28,7 @@ export default function ReferralsDataTable() {
                 <TableRow>
                     <TableHead className="w-[50px]"></TableHead>
                     <TableHead className="w-[100px]">Code</TableHead>
-                    <TableHead>Name</TableHead>
+                    <TableHead>Label</TableHead>
                     <TableHead>Url</TableHead>
                     <TableHead className="w-[100px]">Status</TableHead>
                     <TableHead className="w-[50px]"></TableHead>
@@ -61,7 +61,7 @@ export default function ReferralsDataTable() {
                                     <Copy className="w-6 h-6" />
                                 </TableCell>
                                 <TableCell className="font-medium">{referral.code}</TableCell>
-                                <TableCell>{referral.name}</TableCell>
+                                <TableCell>{referral.label}</TableCell>
                                 <TableCell>{referral.url}</TableCell>
                                 <TableCell><Badge variant="secondary">{referral.disabled ? "Disabled" : "Enabled"}</Badge></TableCell>
                                 <ReferralDeleteConfirmationDialog referral={referral}>

--- a/src/components/dashboard/services/referral/detail/ReferralDetailsCard.tsx
+++ b/src/components/dashboard/services/referral/detail/ReferralDetailsCard.tsx
@@ -27,7 +27,7 @@ export default function ReferralDetailsCard({ referralCode }: { referralCode: Re
         resolver: zodResolver(UpdateReferralFormSchema),
         values: referral,
         defaultValues: {
-            name: "",
+            label: "",
             url: "",
             disabled: false
         },
@@ -77,10 +77,10 @@ export default function ReferralDetailsCard({ referralCode }: { referralCode: Re
                         <form className="space-y-8" onSubmit={form.handleSubmit(onSubmit)}>
                             <FormField
                                 control={form.control}
-                                name="name"
+                                name="label"
                                 render={({field}) => (
                                     <FormItem>
-                                        <FormLabel>Referral Name</FormLabel>
+                                        <FormLabel>Referral Label</FormLabel>
                                         <FormControl>
                                             <Input placeholder="Example Referral" {...field} value={field.value ?? ""}
                                                    type="text"/>

--- a/src/components/dashboard/services/referral/dialog/ReferralCreateDialog.tsx
+++ b/src/components/dashboard/services/referral/dialog/ReferralCreateDialog.tsx
@@ -31,7 +31,7 @@ export default function ReferralCreateDialog({ children }: ReferralCreateDialogP
     const form = useForm<CreateReferralForm>({
         resolver: zodResolver(CreateReferralFormSchema),
         defaultValues: {
-            name: "",
+            label: "",
             url: "",
             disabled: false
         },
@@ -76,10 +76,10 @@ export default function ReferralCreateDialog({ children }: ReferralCreateDialogP
                         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
                             <FormField
                                 control={form.control}
-                                name="name"
+                                name="label"
                                 render={({field}) => (
                                     <FormItem>
-                                        <FormLabel>Referral Name</FormLabel>
+                                        <FormLabel>Referral Label</FormLabel>
                                         <FormControl>
                                             <Input placeholder="Example Referral" {...field} value={field.value ?? ""}
                                                    type="text"/>

--- a/src/components/dashboard/services/referral/dialog/ReferralDeleteConfirmationDialog.tsx
+++ b/src/components/dashboard/services/referral/dialog/ReferralDeleteConfirmationDialog.tsx
@@ -30,9 +30,9 @@ export default function ReferralDeleteConfirmationDialog({ children, referral }:
                 </ DialogTrigger>
                 <DialogContent className="sm:max-w-[425px]" onClick={(event) => event.stopPropagation()}>
                     <DialogHeader>
-                        <DialogTitle>Delete {referral.name ? referral.name : "a referral"}</DialogTitle>
+                        <DialogTitle>Delete {referral.label ? referral.label : "a referral"}</DialogTitle>
                         <DialogDescription>
-                            Please confirm that you want to delete {referral.name ? referral.name : "this referral"}
+                            Please confirm that you want to delete {referral.label ? referral.label : "this referral"}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>

--- a/src/schemas/Forms/ReferralFormSchemas.ts
+++ b/src/schemas/Forms/ReferralFormSchemas.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { ReferralNameSchema } from "../ReferralSchemas";
+import { ReferralLabelSchema } from "../ReferralSchemas";
 import {UrlSchema} from "@/schemas/GenericSchemas.ts";
 
 export const CreateReferralFormSchema = z.object({
-    name: ReferralNameSchema,
+    label: ReferralLabelSchema,
     url: UrlSchema,
     disabled: z.boolean().default(false)
 })
@@ -11,7 +11,7 @@ export const CreateReferralFormSchema = z.object({
 export type CreateReferralForm = z.infer<typeof CreateReferralFormSchema>;
 
 export const UpdateReferralFormSchema = z.object({
-    name: ReferralNameSchema,
+    label: ReferralLabelSchema,
     url: UrlSchema,
     disabled: z.boolean().default(false)
 })

--- a/src/schemas/ReferralSchemas.ts
+++ b/src/schemas/ReferralSchemas.ts
@@ -13,12 +13,12 @@ export const ReferralClickHistoryDataPointSchema = z.object({
 
 export type ReferralClickHistoryDataPoint = z.infer<typeof ReferralClickHistoryDataPointSchema>;
 
-export const ReferralNameSchema = z.string().max(32).regex(/^[a-zA-Z0-9 !@#$%^&*]*$/).nullable()
+export const ReferralLabelSchema = z.string().max(32).regex(/^[a-zA-Z0-9 !@#$%^&*]*$/).nullable()
 
 export const ReferralSchema = z.object({
     code: ReferralCodeSchema,
     url: UrlSchema,
-    name: ReferralNameSchema,
+    label: ReferralLabelSchema,
     disabled: z.boolean(),
     created_at: TimestampSchema,
     updated_at: TimestampSchema,


### PR DESCRIPTION
https://taiga.nebalus.dev/project/nebalus-website/us/30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated referral interface terminology across the app for improved clarity.
	- Table displays now use "Label" instead of "Name."
	- Form interfaces, including creation, details, and deletion dialogs, have been updated to show "Referral Label" replacing the previous "Referral Name."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->